### PR TITLE
use what is on the file patch name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,14 @@ gulp.task("apply-xml-transform", function () {
     .pipe(foreach(function (stream, file) {
       if(file.path.indexOf("web."+build.config.name+".config") == -1 && file.path.indexOf("web."+build.AlwaysApplyName+".config") == -1)
       {
-        var fileToTransform = file.path.slice(file.path.indexOf("App_Config")).replace("."+build.config.name,"");
+        if (file.path.indexOf(build.config.name) != -1)
+	{
+	  var fileToTransform = file.path.slice(file.path.indexOf("App_Config")).replace("."+build.config.name,"");
+	}
+	else
+	{
+	  var fileToTransform = file.path.slice(file.path.indexOf("App_Config")).replace("."+build.AlwaysApplyName,"");
+	}
       }
       else
       {


### PR DESCRIPTION
This fixes so that files with the AlwaysApplyName get the substitution with that and files with build.config.name get substituted with it. Ie. ConnectionStrings.debug.config get 'debug' removed and domains.always.config gets 'always' removed.
